### PR TITLE
feat: Mobile navigation - Add bottom nav bar for screens <1024px

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -8,8 +8,8 @@ export default function DashboardLayout({
     return (
         <div className="min-h-screen bg-background">
             <DashboardNav />
-            {/* Add bottom padding on mobile to account for bottom nav */}
-            <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 pb-24 md:pb-8">
+            {/* Add bottom padding on mobile/tablet (<1024px) to account for bottom nav */}
+            <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 pb-24 lg:pb-8">
                 {children}
             </main>
         </div>

--- a/components/layout/nav.tsx
+++ b/components/layout/nav.tsx
@@ -51,7 +51,7 @@ export function DashboardNav() {
 
     return (
         <>
-            {/* Desktop & Tablet Navigation */}
+            {/* Desktop Navigation (>=1024px) */}
             <nav className="border-b bg-background">
                 <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                     <div className="flex h-16 justify-between">
@@ -61,8 +61,8 @@ export function DashboardNav() {
                                     progress.now
                                 </Link>
                             </div>
-                            {/* Desktop Navigation */}
-                            <div className="hidden md:ml-8 md:flex md:space-x-8">
+                            {/* Desktop Navigation - visible only on lg screens and above */}
+                            <div className="hidden lg:ml-8 lg:flex lg:space-x-8">
                                 {navigation.map((item) => {
                                     const isActive = pathname === item.href
                                     const Icon = item.icon
@@ -93,12 +93,12 @@ export function DashboardNav() {
                                 <LogOut className="h-4 w-4" />
                                 <span className="sr-only">Logout</span>
                             </Button>
-                            {/* Mobile Menu Button */}
+                            {/* Mobile/Tablet Menu Button - visible below lg breakpoint */}
                             <Button
                                 variant="ghost"
                                 size="icon"
                                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                                className="md:hidden"
+                                className="lg:hidden"
                             >
                                 {mobileMenuOpen ? (
                                     <X className="h-5 w-5" />
@@ -111,9 +111,9 @@ export function DashboardNav() {
                     </div>
                 </div>
 
-                {/* Mobile Slide-Down Menu */}
+                {/* Mobile/Tablet Slide-Down Menu - visible below lg breakpoint */}
                 {mobileMenuOpen && (
-                    <div className="md:hidden border-t">
+                    <div className="lg:hidden border-t">
                         <div className="space-y-1 px-4 pb-3 pt-2">
                             {navigation.map((item) => {
                                 const isActive = pathname === item.href
@@ -148,8 +148,12 @@ export function DashboardNav() {
                 )}
             </nav>
 
-            {/* Mobile Bottom Navigation */}
-            <nav className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background md:hidden safe-area-bottom">
+            {/* Mobile/Tablet Bottom Navigation - visible below lg breakpoint (<1024px) */}
+            <nav 
+                className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background lg:hidden safe-area-bottom"
+                role="navigation"
+                aria-label="Mobile navigation"
+            >
                 <div className="grid grid-cols-5 h-16">
                     {navigation.map((item) => {
                         const isActive = pathname === item.href
@@ -158,24 +162,26 @@ export function DashboardNav() {
                             <Link
                                 key={item.name}
                                 href={item.href}
-                                className={`flex flex-col items-center justify-center gap-1 transition-colors ${isActive
+                                aria-current={isActive ? 'page' : undefined}
+                                className={`flex flex-col items-center justify-center gap-1 transition-colors min-h-[44px] ${isActive
                                         ? 'text-primary'
-                                        : 'text-muted-foreground hover:text-foreground'
+                                        : 'text-muted-foreground hover:text-foreground active:text-foreground'
                                     }`}
                             >
                                 <Icon className="h-5 w-5" />
-                                <span className="text-xs font-medium">{item.name}</span>
+                                <span className="text-xs font-medium truncate max-w-full px-1">{item.name}</span>
                             </Link>
                         )
                     })}
                 </div>
             </nav>
 
-            {/* Mobile Menu Backdrop */}
+            {/* Mobile/Tablet Menu Backdrop - visible below lg breakpoint */}
             {mobileMenuOpen && (
                 <div
-                    className="fixed inset-0 z-40 bg-black/20 md:hidden"
+                    className="fixed inset-0 z-40 bg-black/20 lg:hidden"
                     onClick={closeMobileMenu}
+                    aria-hidden="true"
                 />
             )}
         </>

--- a/tests/components/nav.test.tsx
+++ b/tests/components/nav.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DashboardNav } from '@/components/layout/nav'
+import { usePathname } from 'next/navigation'
+
+// Mock next-themes
+vi.mock('next-themes', () => ({
+    useTheme: vi.fn(() => ({
+        theme: 'light',
+        setTheme: vi.fn(),
+    })),
+}))
+
+describe('DashboardNav', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('Navigation Items', () => {
+        it('renders all navigation items', () => {
+            render(<DashboardNav />)
+            
+            expect(screen.getAllByText('Dashboard').length).toBeGreaterThan(0)
+            expect(screen.getAllByText('TODOs').length).toBeGreaterThan(0)
+            expect(screen.getAllByText('Projects').length).toBeGreaterThan(0)
+            expect(screen.getAllByText('Research').length).toBeGreaterThan(0)
+            expect(screen.getAllByText('Settings').length).toBeGreaterThan(0)
+        })
+
+        it('renders the app logo/title', () => {
+            render(<DashboardNav />)
+            
+            expect(screen.getByText('progress.now')).toBeInTheDocument()
+        })
+    })
+
+    describe('Bottom Navigation', () => {
+        it('renders bottom navigation with correct aria attributes', () => {
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            expect(bottomNav).toBeInTheDocument()
+        })
+
+        it('bottom nav has lg:hidden class for <1024px visibility', () => {
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            expect(bottomNav).toHaveClass('lg:hidden')
+        })
+
+        it('bottom nav contains all 5 navigation items', () => {
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const links = bottomNav.querySelectorAll('a')
+            expect(links).toHaveLength(5)
+        })
+
+        it('bottom nav items have correct hrefs', () => {
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const links = bottomNav.querySelectorAll('a')
+            
+            const hrefs = Array.from(links).map(link => link.getAttribute('href'))
+            expect(hrefs).toContain('/dashboard')
+            expect(hrefs).toContain('/dashboard/todos')
+            expect(hrefs).toContain('/dashboard/projects')
+            expect(hrefs).toContain('/dashboard/research')
+            expect(hrefs).toContain('/dashboard/settings')
+        })
+    })
+
+    describe('Active Route Highlighting', () => {
+        it('highlights Dashboard when on /dashboard', () => {
+            vi.mocked(usePathname).mockReturnValue('/dashboard')
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const dashboardLink = bottomNav.querySelector('a[href="/dashboard"]')
+            
+            expect(dashboardLink).toHaveClass('text-primary')
+            expect(dashboardLink).toHaveAttribute('aria-current', 'page')
+        })
+
+        it('highlights TODOs when on /dashboard/todos', () => {
+            vi.mocked(usePathname).mockReturnValue('/dashboard/todos')
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const todosLink = bottomNav.querySelector('a[href="/dashboard/todos"]')
+            
+            expect(todosLink).toHaveClass('text-primary')
+            expect(todosLink).toHaveAttribute('aria-current', 'page')
+        })
+
+        it('highlights Projects when on /dashboard/projects', () => {
+            vi.mocked(usePathname).mockReturnValue('/dashboard/projects')
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const projectsLink = bottomNav.querySelector('a[href="/dashboard/projects"]')
+            
+            expect(projectsLink).toHaveClass('text-primary')
+            expect(projectsLink).toHaveAttribute('aria-current', 'page')
+        })
+
+        it('highlights Research when on /dashboard/research', () => {
+            vi.mocked(usePathname).mockReturnValue('/dashboard/research')
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const researchLink = bottomNav.querySelector('a[href="/dashboard/research"]')
+            
+            expect(researchLink).toHaveClass('text-primary')
+            expect(researchLink).toHaveAttribute('aria-current', 'page')
+        })
+
+        it('highlights Settings when on /dashboard/settings', () => {
+            vi.mocked(usePathname).mockReturnValue('/dashboard/settings')
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const settingsLink = bottomNav.querySelector('a[href="/dashboard/settings"]')
+            
+            expect(settingsLink).toHaveClass('text-primary')
+            expect(settingsLink).toHaveAttribute('aria-current', 'page')
+        })
+
+        it('non-active items do not have aria-current', () => {
+            vi.mocked(usePathname).mockReturnValue('/dashboard')
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const todosLink = bottomNav.querySelector('a[href="/dashboard/todos"]')
+            
+            expect(todosLink).not.toHaveAttribute('aria-current')
+            expect(todosLink).toHaveClass('text-muted-foreground')
+        })
+    })
+
+    describe('Touch Friendliness', () => {
+        it('bottom nav items have minimum touch target size', () => {
+            render(<DashboardNav />)
+            
+            const bottomNav = screen.getByRole('navigation', { name: 'Mobile navigation' })
+            const links = bottomNav.querySelectorAll('a')
+            
+            links.forEach(link => {
+                expect(link).toHaveClass('min-h-[44px]')
+            })
+        })
+    })
+
+    describe('Desktop Navigation', () => {
+        it('desktop nav has lg:flex class for >=1024px visibility', () => {
+            render(<DashboardNav />)
+            
+            // Find the desktop navigation container
+            const desktopNav = document.querySelector('.lg\\:flex.lg\\:space-x-8')
+            expect(desktopNav).toBeInTheDocument()
+            expect(desktopNav).toHaveClass('hidden')
+        })
+    })
+
+    describe('Responsive Breakpoints', () => {
+        it('menu button has lg:hidden class', () => {
+            render(<DashboardNav />)
+            
+            const menuButton = screen.getByRole('button', { name: 'Toggle menu' })
+            expect(menuButton).toHaveClass('lg:hidden')
+        })
+    })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,2 +1,28 @@
-// Test setup file
-export { }
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/dashboard'),
+    useRouter: vi.fn(() => ({
+        push: vi.fn(),
+        refresh: vi.fn(),
+    })),
+}))
+
+// Mock Supabase client
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: vi.fn(() => ({
+        auth: {
+            signOut: vi.fn(() => Promise.resolve({ error: null })),
+        },
+    })),
+}))
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+    },
+}))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import path from 'path'
 export default defineConfig({
     plugins: [react()],
     test: {
-        environment: 'node',
+        environment: 'jsdom',
         globals: true,
         setupFiles: ['./tests/setup.ts'],
     },


### PR DESCRIPTION
## Summary

This PR implements the mobile bottom navigation bar feature as requested in #1.

## Changes

### Navigation Component (`components/layout/nav.tsx`)
- Changed bottom navigation visibility from `md:hidden` to `lg:hidden` (now visible on screens <1024px)
- Updated desktop navigation visibility from `md:flex` to `lg:flex` (now hidden on screens <1024px)
- Updated hamburger menu button visibility from `md:hidden` to `lg:hidden`
- Added accessibility attributes:
  - `role="navigation"` and `aria-label="Mobile navigation"` to bottom nav
  - `aria-current="page"` for active route highlighting
  - `aria-hidden="true"` for backdrop overlay
- Added `min-h-[44px]` to bottom nav items for touch-friendly tap targets
- Added `active:text-foreground` for better touch feedback

### Dashboard Layout (`app/dashboard/layout.tsx`)
- Updated bottom padding from `pb-24 md:pb-8` to `pb-24 lg:pb-8` to account for bottom nav on tablet screens

### Test Infrastructure
- Updated `vitest.config.ts` to use `jsdom` environment for React component testing
- Enhanced `tests/setup.ts` with mocks for Next.js navigation, Supabase client, and sonner toast
- Added comprehensive test suite in `tests/components/nav.test.tsx` (15 tests)

## Test Results

All 41 tests pass:
```
✓ lib/gamification/__tests__/xp-calculator.test.ts (26 tests)
✓ tests/components/nav.test.tsx (15 tests)
```

## Acceptance Criteria

- [x] Bottom navigation bar on screens <1024px
- [x] Include: Dashboard, TODOs, Projects, Research, Settings
- [x] Highlight active route
- [x] Keep desktop sidebar unchanged
- [x] Must be responsive and touch friendly
- [x] Must not break auth or routing
- [x] All pages accessible on mobile
- [x] Settings visible on mobile
- [x] No horizontal scrolling
- [x] No layout break on desktop

## Screenshots

The bottom navigation now appears on both mobile (<768px) and tablet (768px-1024px) screens, providing consistent navigation across all smaller devices.

Closes #1

@Sour-abh-Raj can click here to [continue refining the PR](https://app.all-hands.dev/conversations/70e4c4483d3040f3bf8f613a1c40a66a)