### PR TITLE
Improve dashboard performance: aggregated server queries + reduced client refetching

### DIFF
--- a/components/providers/query-provider.tsx
+++ b/components/providers/query-provider.tsx
@@ -16,7 +16,9 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
                         // Retry failed requests once
                         retry: 1,
                         // Refetch on window focus for fresh data
-                        refetchOnWindowFocus: true,
+                        refetchOnWindowFocus: false,
+                        // Avoid surprise network churn when reconnecting from flaky networks
+                        refetchOnReconnect: false,
                         // Don't refetch on mount if data is fresh
                         refetchOnMount: false,
                     },

--- a/lib/hooks/use-todos.ts
+++ b/lib/hooks/use-todos.ts
@@ -89,7 +89,10 @@ export function useToggleTodo() {
 
             return { previousTodos, wasCompleted: todo?.completed }
         },
-        onSuccess: (_, __, context) => {
+        onSuccess: (updatedTodo, _, context) => {
+            queryClient.setQueryData<Todo[]>(TODOS_QUERY_KEY, (old) =>
+                old?.map((todo) => (todo.id === updatedTodo.id ? updatedTodo : todo)) ?? []
+            )
             toast.success(context?.wasCompleted ? 'Todo uncompleted' : 'Todo completed! 🎉')
         },
         onError: (_, __, context) => {
@@ -97,10 +100,6 @@ export function useToggleTodo() {
                 queryClient.setQueryData(TODOS_QUERY_KEY, context.previousTodos)
             }
             toast.error('Failed to update todo')
-        },
-        onSettled: () => {
-            // Refetch to ensure consistency
-            queryClient.invalidateQueries({ queryKey: TODOS_QUERY_KEY })
         },
     })
 }


### PR DESCRIPTION
### Motivation
- The dashboard was loading full collections (todos/projects) on every request which increased payload sizes and response time.  
- Client-side React Query settings caused extra network churn on focus/reconnects, harming perceived snappiness.  
- Mutations unnecessarily triggered a refetch after toggles, creating an extra round-trip and delaying UI updates.  

### Description
- Added a request-scoped cached Supabase helper `getServerSupabaseClient` to reuse the server client across cached queries.  
- Implemented `getDashboardMetrics` to fetch lightweight aggregated counts and a `weeklyScore` in a single parallel query batch for the dashboard.  
- Added `getCachedTodosDueToday` (lightweight `DashboardTodo` shape) and updated `app/dashboard/page.tsx` to use these aggregated helpers instead of fetching full collections.  
- Tuned React Query defaults in `components/providers/query-provider.tsx` by setting `refetchOnWindowFocus: false` and `refetchOnReconnect: false` to reduce background refetch churn.  
- Improved todo toggle mutation in `lib/hooks/use-todos.ts` to reconcile cache with the server response on success and removed the forced `invalidateQueries` to avoid an immediate extra fetch.  
- Minor UI text fixes to escape apostrophes in the dashboard to satisfy lint rules.  

### Testing
- Ran unit tests: `npm run test:unit -- tests/performance/caching.test.ts tests/performance/client-cache.test.ts` and all tests passed (32 tests across 2 files).  
- Ran `npm run test:unit -- tests/performance/caching.test.ts` and it passed.  
- Ran `npm run lint` which still reports repository pre-existing lint issues unrelated to these changes (final run: `✖ 19 problems (9 errors, 10 warnings)`), but the dashboard apostrophes were fixed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a501769508328ae84b3c7488f3de2)